### PR TITLE
fix floating img covered by text

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,8 @@
 
 					<!-- Logo -->
 						<div id="logo">
-							<span class="image avatar50"><img src="images/PetiaPhoto.png"/></span>
+							<!-- <span class="image avatar50"></span> -->
+							<img src="images/PetiaPhoto.png"/>
 							<h1 id="title">Petia Yanchulova Merica-Jones</h1>
 							<p>Postdoctoral Researcher</p>
 							<p><a href="mailto:pyanchulova@stsci.edu"> <span class="icon solid fa-envelope">  Contact</span></a>


### PR DESCRIPTION
Removed `<span class="image avatar50"></span>` in Logo section.
Originally the text was `<span class="image avatar48"></span>`, which made the image too small.